### PR TITLE
STELLAR-1452 Stellarstation source blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+.gogradle
+/vendor
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+*.iml
+*.ipr
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### Gradle template
+.gradle
+build
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+# Compiled GNURadio flowgraphs
+flowgraphs/*.py
+
+# Generated golang code
+*.pb.go
+
+# Don't check-in generated go-rice
+*rice-box.go
+
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ cmake_minimum_required(VERSION 2.6)
 project(gr-stellarstation CXX C)
 enable_testing()
 
+# Enable C++11 support
+ set (CMAKE_CXX_STANDARD 11)
+ add_definitions(-std=c++11)
+
 #install to PyBOMBS target prefix if defined
 if(DEFINED ENV{PYBOMBS_PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})
@@ -63,6 +67,24 @@ endif()
 if(POLICY CMP0046)
     cmake_policy(SET CMP0046 OLD)
 endif()
+
+########################################################################
+# Fetch Stellarstation API .proto
+########################################################################
+include(DownloadProject)
+download_project(PROJ stellarstation-api
+                 GIT_REPOSITORY https://github.com/infostellarinc/stellarstation-api.git
+                 GIT_TAG master)
+message(STATUS "stellarstation-api repo stored in ${stellarstation-api_SOURCE_DIR}")
+
+########################################################################
+# Find grgrpc dependencies
+########################################################################
+find_package(Protobuf REQUIRED)
+message(STATUS "Using protobuf ${protobuf_VERSION}")
+
+find_package(gRPC CONFIG REQUIRED)
+message(STATUS "Using gRPC ${gRPC_VERSION}")
 
 ########################################################################
 # Compiler specific setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ endif(APPLE)
 # Find gnuradio build dependencies
 ########################################################################
 find_package(CppUnit)
+find_package(Log4cpp)
 find_package(Doxygen)
 
 # Search for GNU Radio and its components and versions. Add any
@@ -179,6 +180,12 @@ if(DOXYGEN_FOUND)
 else(DOXYGEN_FOUND)
 	option(ENABLE_DOXYGEN "Build docs using Doxygen" OFF)
 endif(DOXYGEN_FOUND)
+
+########################################################################
+# Setup logging
+########################################################################
+include(GrMiscUtils)
+GR_LOGGING()
 
 ########################################################################
 # Setup the include and linker paths

--- a/cmake/Modules/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/Modules/DownloadProject.CMakeLists.cmake.in
@@ -1,0 +1,17 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(${DL_ARGS_PROJ}-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(${DL_ARGS_PROJ}-download
+                    ${DL_ARGS_UNPARSED_ARGUMENTS}
+                    SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
+                    BINARY_DIR          "${DL_ARGS_BINARY_DIR}"
+                    CONFIGURE_COMMAND   ""
+                    BUILD_COMMAND       ""
+                    INSTALL_COMMAND     ""
+                    TEST_COMMAND        ""
+)

--- a/cmake/Modules/DownloadProject.cmake
+++ b/cmake/Modules/DownloadProject.cmake
@@ -1,0 +1,182 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
+# MODULE:   DownloadProject
+#
+# PROVIDES:
+#   download_project( PROJ projectName
+#                    [PREFIX prefixDir]
+#                    [DOWNLOAD_DIR downloadDir]
+#                    [SOURCE_DIR srcDir]
+#                    [BINARY_DIR binDir]
+#                    [QUIET]
+#                    ...
+#   )
+#
+#       Provides the ability to download and unpack a tarball, zip file, git repository,
+#       etc. at configure time (i.e. when the cmake command is run). How the downloaded
+#       and unpacked contents are used is up to the caller, but the motivating case is
+#       to download source code which can then be included directly in the build with
+#       add_subdirectory() after the call to download_project(). Source and build
+#       directories are set up with this in mind.
+#
+#       The PROJ argument is required. The projectName value will be used to construct
+#       the following variables upon exit (obviously replace projectName with its actual
+#       value):
+#
+#           projectName_SOURCE_DIR
+#           projectName_BINARY_DIR
+#
+#       The SOURCE_DIR and BINARY_DIR arguments are optional and would not typically
+#       need to be provided. They can be specified if you want the downloaded source
+#       and build directories to be located in a specific place. The contents of
+#       projectName_SOURCE_DIR and projectName_BINARY_DIR will be populated with the
+#       locations used whether you provide SOURCE_DIR/BINARY_DIR or not.
+#
+#       The DOWNLOAD_DIR argument does not normally need to be set. It controls the
+#       location of the temporary CMake build used to perform the download.
+#
+#       The PREFIX argument can be provided to change the base location of the default
+#       values of DOWNLOAD_DIR, SOURCE_DIR and BINARY_DIR. If all of those three arguments
+#       are provided, then PREFIX will have no effect. The default value for PREFIX is
+#       CMAKE_BINARY_DIR.
+#
+#       The QUIET option can be given if you do not want to show the output associated
+#       with downloading the specified project.
+#
+#       In addition to the above, any other options are passed through unmodified to
+#       ExternalProject_Add() to perform the actual download, patch and update steps.
+#       The following ExternalProject_Add() options are explicitly prohibited (they
+#       are reserved for use by the download_project() command):
+#
+#           CONFIGURE_COMMAND
+#           BUILD_COMMAND
+#           INSTALL_COMMAND
+#           TEST_COMMAND
+#
+#       Only those ExternalProject_Add() arguments which relate to downloading, patching
+#       and updating of the project sources are intended to be used. Also note that at
+#       least one set of download-related arguments are required.
+#
+#       If using CMake 3.2 or later, the UPDATE_DISCONNECTED option can be used to
+#       prevent a check at the remote end for changes every time CMake is run
+#       after the first successful download. See the documentation of the ExternalProject
+#       module for more information. It is likely you will want to use this option if it
+#       is available to you. Note, however, that the ExternalProject implementation contains
+#       bugs which result in incorrect handling of the UPDATE_DISCONNECTED option when
+#       using the URL download method or when specifying a SOURCE_DIR with no download
+#       method. Fixes for these have been created, the last of which is scheduled for
+#       inclusion in CMake 3.8.0. Details can be found here:
+#
+#           https://gitlab.kitware.com/cmake/cmake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c
+#           https://gitlab.kitware.com/cmake/cmake/issues/16428
+#
+#       If you experience build errors related to the update step, consider avoiding
+#       the use of UPDATE_DISCONNECTED.
+#
+# EXAMPLE USAGE:
+#
+#   include(DownloadProject)
+#   download_project(PROJ                googletest
+#                    GIT_REPOSITORY      https://github.com/google/googletest.git
+#                    GIT_TAG             master
+#                    UPDATE_DISCONNECTED 1
+#                    QUIET
+#   )
+#
+#   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+#
+#========================================================================================
+
+
+set(_DownloadProjectDir "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeParseArguments)
+
+function(download_project)
+
+    set(options QUIET)
+    set(oneValueArgs
+        PROJ
+        PREFIX
+        DOWNLOAD_DIR
+        SOURCE_DIR
+        BINARY_DIR
+        # Prevent the following from being passed through
+        CONFIGURE_COMMAND
+        BUILD_COMMAND
+        INSTALL_COMMAND
+        TEST_COMMAND
+    )
+    set(multiValueArgs "")
+
+    cmake_parse_arguments(DL_ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Hide output if requested
+    if (DL_ARGS_QUIET)
+        set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+        unset(OUTPUT_QUIET)
+        message(STATUS "Downloading/updating ${DL_ARGS_PROJ}")
+    endif()
+
+    # Set up where we will put our temporary CMakeLists.txt file and also
+    # the base point below which the default source and binary dirs will be.
+    # The prefix must always be an absolute path.
+    if (NOT DL_ARGS_PREFIX)
+        set(DL_ARGS_PREFIX "${CMAKE_BINARY_DIR}")
+    else()
+        get_filename_component(DL_ARGS_PREFIX "${DL_ARGS_PREFIX}" ABSOLUTE
+                               BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    if (NOT DL_ARGS_DOWNLOAD_DIR)
+        set(DL_ARGS_DOWNLOAD_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-download")
+    endif()
+
+    # Ensure the caller can know where to find the source and build directories
+    if (NOT DL_ARGS_SOURCE_DIR)
+        set(DL_ARGS_SOURCE_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-src")
+    endif()
+    if (NOT DL_ARGS_BINARY_DIR)
+        set(DL_ARGS_BINARY_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-build")
+    endif()
+    set(${DL_ARGS_PROJ}_SOURCE_DIR "${DL_ARGS_SOURCE_DIR}" PARENT_SCOPE)
+    set(${DL_ARGS_PROJ}_BINARY_DIR "${DL_ARGS_BINARY_DIR}" PARENT_SCOPE)
+
+    # The way that CLion manages multiple configurations, it causes a copy of
+    # the CMakeCache.txt to be copied across due to it not expecting there to
+    # be a project within a project.  This causes the hard-coded paths in the
+    # cache to be copied and builds to fail.  To mitigate this, we simply
+    # remove the cache if it exists before we configure the new project.  It
+    # is safe to do so because it will be re-generated.  Since this is only
+    # executed at the configure step, it should not cause additional builds or
+    # downloads.
+    file(REMOVE "${DL_ARGS_DOWNLOAD_DIR}/CMakeCache.txt")
+
+    # Create and build a separate CMake project to carry out the download.
+    # If we've already previously done these steps, they will not cause
+    # anything to be updated, so extra rebuilds of the project won't occur.
+    # Make sure to pass through CMAKE_MAKE_PROGRAM in case the main project
+    # has this set to something not findable on the PATH.
+    configure_file("${_DownloadProjectDir}/DownloadProject.CMakeLists.cmake.in"
+                   "${DL_ARGS_DOWNLOAD_DIR}/CMakeLists.txt")
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+                        -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+                        .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "CMake step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "Build step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+
+endfunction()

--- a/cmake/Modules/FindLog4cpp.cmake
+++ b/cmake/Modules/FindLog4cpp.cmake
@@ -1,0 +1,53 @@
+# - Find Log4cpp
+# Find the native LOG4CPP includes and library
+#
+#  LOG4CPP_INCLUDE_DIR - where to find LOG4CPP.h, etc.
+#  LOG4CPP_LIBRARIES   - List of libraries when using LOG4CPP.
+#  LOG4CPP_FOUND       - True if LOG4CPP found.
+
+
+if (LOG4CPP_INCLUDE_DIR)
+  # Already in cache, be silent
+  set(LOG4CPP_FIND_QUIETLY TRUE)
+endif ()
+
+find_path(LOG4CPP_INCLUDE_DIR log4cpp/Category.hh
+  /opt/local/include
+  /usr/local/include
+  /usr/include
+)
+
+set(LOG4CPP_NAMES log4cpp)
+find_library(LOG4CPP_LIBRARY
+  NAMES ${LOG4CPP_NAMES}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib
+)
+
+
+if (LOG4CPP_INCLUDE_DIR AND LOG4CPP_LIBRARY)
+  set(LOG4CPP_FOUND TRUE)
+  set(LOG4CPP_LIBRARIES ${LOG4CPP_LIBRARY} CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS ${LOG4CPP_INCLUDE_DIR} CACHE INTERNAL "" FORCE)
+else ()
+  set(LOG4CPP_FOUND FALSE CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARY "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIR "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
+endif ()
+
+if (LOG4CPP_FOUND)
+  if (NOT LOG4CPP_FIND_QUIETLY)
+    message(STATUS "Found LOG4CPP: ${LOG4CPP_LIBRARIES}")
+  endif ()
+else ()
+  if (LOG4CPP_FIND_REQUIRED)
+    message(STATUS "Looked for LOG4CPP libraries named ${LOG4CPPS_NAMES}.")
+    message(FATAL_ERROR "Could NOT find LOG4CPP library")
+  endif ()
+endif ()
+
+mark_as_advanced(
+  LOG4CPP_LIBRARIES
+  LOG4CPP_INCLUDE_DIRS
+)

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -21,5 +21,6 @@
 install(FILES
     stellarstation_api_source.xml
     stellarstation_pdu_to_stream.xml
-    stellarstation_iq_source.xml DESTINATION share/gnuradio/grc/blocks
+    stellarstation_iq_source.xml
+    stellarstation_bitstream_source.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -19,5 +19,6 @@
 # Boston, MA 02110-1301, USA.
 
 install(FILES
-    stellarstation_api_source.xml DESTINATION share/gnuradio/grc/blocks
+    stellarstation_api_source.xml
+    stellarstation_pdu_to_stream.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -20,5 +20,6 @@
 
 install(FILES
     stellarstation_api_source.xml
-    stellarstation_pdu_to_stream.xml DESTINATION share/gnuradio/grc/blocks
+    stellarstation_pdu_to_stream.xml
+    stellarstation_iq_source.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -19,5 +19,5 @@
 # Boston, MA 02110-1301, USA.
 
 install(FILES
-    DESTINATION share/gnuradio/grc/blocks
+    stellarstation_api_source.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<block>
+  <name>Stellarstation API Source</name>
+  <key>stellarstation_api_source</key>
+  <category>[stellarstation]</category>
+  <import>import stellarstation</import>
+  <make>stellarstation.api_source()</make>
+
+  <source>
+    <name>out</name>
+    <type>message</type>
+  </source>
+
+</block>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -4,7 +4,14 @@
   <key>stellarstation_api_source</key>
   <category>[stellarstation]</category>
   <import>import stellarstation</import>
-  <make>stellarstation.api_source()</make>
+  <make>stellarstation.api_source($key)</make>
+
+  <param>
+    <name>Stellarstation API Key Filepath</name>
+    <key>key</key>
+    <value></value>
+    <type>file_open</type>
+  </param>
 
   <source>
     <name>out</name>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -4,7 +4,7 @@
   <key>stellarstation_api_source</key>
   <category>[stellarstation]</category>
   <import>import stellarstation</import>
-  <make>stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path)</make>
+  <make>stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
 
   <param>
     <name>Satellite ID</name>
@@ -32,6 +32,13 @@
     <key>root_cert_path</key>
     <value></value>
     <type>file_open</type>
+  </param>
+
+  <param>
+    <name>Stellarstation API URL</name>
+    <key>api_url</key>
+    <value>"api.stellarstation.com"</value>
+    <type>string</type>
   </param>
 
   <source>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -3,8 +3,8 @@
   <name>Stellarstation API Source</name>
   <key>stellarstation_api_source</key>
   <category>[stellarstation]/core</category>
-  <import>import stellarstation</import>
-  <make>stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
+  <import>import gr_stellarstation</import>
+  <make>gr_stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
 
   <param>
     <name>Satellite ID</name>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -4,11 +4,18 @@
   <key>stellarstation_api_source</key>
   <category>[stellarstation]</category>
   <import>import stellarstation</import>
-  <make>stellarstation.api_source($key)</make>
+  <make>stellarstation.api_source($key, $root_cert_path)</make>
 
   <param>
     <name>Stellarstation API Key Filepath</name>
     <key>key</key>
+    <value></value>
+    <type>file_open</type>
+  </param>
+
+  <param>
+    <name>Fake Server tls.crt Filepath</name>
+    <key>root_cert_path</key>
     <value></value>
     <type>file_open</type>
   </param>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Stellarstation API Source</name>
   <key>stellarstation_api_source</key>
-  <category>[stellarstation]</category>
+  <category>[stellarstation]/core</category>
   <import>import stellarstation</import>
   <make>stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
 

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -32,6 +32,7 @@
     <key>root_cert_path</key>
     <value></value>
     <type>file_open</type>
+    <hide>part</hide>
   </param>
 
   <param>
@@ -39,6 +40,7 @@
     <key>api_url</key>
     <value>"api.stellarstation.com"</value>
     <type>string</type>
+    <hide>part</hide>
   </param>
 
   <source>

--- a/grc/stellarstation_api_source.xml
+++ b/grc/stellarstation_api_source.xml
@@ -4,7 +4,21 @@
   <key>stellarstation_api_source</key>
   <category>[stellarstation]</category>
   <import>import stellarstation</import>
-  <make>stellarstation.api_source($key, $root_cert_path)</make>
+  <make>stellarstation.api_source($satellite_id, $stream_id, $key, $root_cert_path)</make>
+
+  <param>
+    <name>Satellite ID</name>
+    <key>satellite_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
+
+  <param>
+    <name>Stream ID</name>
+    <key>stream_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
 
   <param>
     <name>Stellarstation API Key Filepath</name>

--- a/grc/stellarstation_bitstream_source.xml
+++ b/grc/stellarstation_bitstream_source.xml
@@ -3,8 +3,8 @@
   <name>Stellarstation Bitstream Source</name>
   <key>stellarstation_bitstream_source</key>
   <category>[stellarstation]</category>
-  <import>import stellarstation</import>
-  <make>stellarstation.bitstream_source($satellite_id, $stream_id, $key_path, $root_cert_path, $api_url)</make>
+  <import>import gr_stellarstation</import>
+  <make>gr_stellarstation.bitstream_source($satellite_id, $stream_id, $key_path, $root_cert_path, $api_url)</make>
   <param>
     <name>Satellite ID</name>
     <key>satellite_id</key>

--- a/grc/stellarstation_bitstream_source.xml
+++ b/grc/stellarstation_bitstream_source.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<block>
+  <name>Stellarstation Bitstream Source</name>
+  <key>stellarstation_bitstream_source</key>
+  <category>[stellarstation]</category>
+  <import>import stellarstation</import>
+  <make>stellarstation.bitstream_source($satellite_id, $stream_id, $key_path, $root_cert_path, $api_url)</make>
+  <param>
+    <name>Satellite ID</name>
+    <key>satellite_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
+
+  <param>
+    <name>Stream ID</name>
+    <key>stream_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
+
+  <param>
+    <name>Stellarstation API Key Filepath</name>
+    <key>key_path</key>
+    <value></value>
+    <type>file_open</type>
+  </param>
+
+  <param>
+    <name>Fake Server tls.crt Filepath</name>
+    <key>root_cert_path</key>
+    <value></value>
+    <type>file_open</type>
+    <hide>part</hide>
+  </param>
+
+  <param>
+    <name>Stellarstation API URL</name>
+    <key>api_url</key>
+    <value>"api.stellarstation.com"</value>
+    <type>string</type>
+    <hide>part</hide>
+  </param>
+
+  <source>
+    <name>out</name>
+    <type>byte</type>
+  </source>
+
+</block>

--- a/grc/stellarstation_iq_source.xml
+++ b/grc/stellarstation_iq_source.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<block>
+  <name>Stellarstation IQ Source</name>
+  <key>stellarstation_iq_source</key>
+  <category>[stellarstation]</category>
+  <import>import stellarstation</import>
+  <make>stellarstation.iq_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
+
+  <param>
+    <name>Satellite ID</name>
+    <key>satellite_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
+
+  <param>
+    <name>Stream ID</name>
+    <key>stream_id</key>
+    <value>""</value>
+    <type>string</type>
+  </param>
+
+  <param>
+    <name>Stellarstation API Key Filepath</name>
+    <key>key</key>
+    <value></value>
+    <type>file_open</type>
+  </param>
+
+  <param>
+    <name>Fake Server tls.crt Filepath</name>
+    <key>root_cert_path</key>
+    <value></value>
+    <type>file_open</type>
+  </param>
+
+  <param>
+    <name>Stellarstation API URL</name>
+    <key>api_url</key>
+    <value>"api.stellarstation.com"</value>
+    <type>string</type>
+  </param>
+
+  <source>
+    <name>out</name>
+    <type>complex</type>
+  </source>
+
+</block>

--- a/grc/stellarstation_iq_source.xml
+++ b/grc/stellarstation_iq_source.xml
@@ -3,8 +3,8 @@
   <name>Stellarstation IQ Source</name>
   <key>stellarstation_iq_source</key>
   <category>[stellarstation]</category>
-  <import>import stellarstation</import>
-  <make>stellarstation.iq_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
+  <import>import gr_stellarstation</import>
+  <make>gr_stellarstation.iq_source($satellite_id, $stream_id, $key, $root_cert_path, $api_url)</make>
 
   <param>
     <name>Satellite ID</name>

--- a/grc/stellarstation_iq_source.xml
+++ b/grc/stellarstation_iq_source.xml
@@ -32,6 +32,7 @@
     <key>root_cert_path</key>
     <value></value>
     <type>file_open</type>
+    <hide>part</hide>
   </param>
 
   <param>
@@ -39,6 +40,7 @@
     <key>api_url</key>
     <value>"api.stellarstation.com"</value>
     <type>string</type>
+    <hide>part</hide>
   </param>
 
   <source>

--- a/grc/stellarstation_pdu_to_stream.xml
+++ b/grc/stellarstation_pdu_to_stream.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<block>
+  <name>PDU to Stream</name>
+  <key>stellarstation_pdu_to_stream</key>
+  <category>[stellarstation]</category>
+  <import>from gnuradio import blocks</import>
+  <import>import stellarstation</import>
+  <make>stellarstation.pdu_to_stream($type.size)</make>
+
+  <param>
+    <name>Output Type</name>
+    <key>type</key>
+    <type>enum</type>
+    <option>
+      <name>Complex</name>
+      <key>complex</key>
+      <opt>size:gr.sizeof_gr_complex</opt>
+    </option>
+    <option>
+      <name>Float</name>
+      <key>float</key>
+      <opt>size:gr.sizeof_float</opt>
+    </option>
+    <option>
+      <name>Int</name>
+      <key>int</key>
+      <opt>size:gr.sizeof_int</opt>
+    </option>
+    <option>
+      <name>Short</name>
+      <key>short</key>
+      <opt>size:gr.sizeof_short</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>byte</key>
+      <opt>size:gr.sizeof_char</opt>
+    </option>
+  </param>
+
+  <sink>
+    <name>pdu</name>
+    <type>message</type>
+  </sink>
+
+  <source>
+    <name>out</name>
+    <type>$type</type>
+  </source>
+</block>

--- a/grc/stellarstation_pdu_to_stream.xml
+++ b/grc/stellarstation_pdu_to_stream.xml
@@ -4,8 +4,8 @@
   <key>stellarstation_pdu_to_stream</key>
   <category>[stellarstation]/util</category>
   <import>from gnuradio import blocks</import>
-  <import>import stellarstation</import>
-  <make>stellarstation.pdu_to_stream($type.size)</make>
+  <import>import gr_stellarstation</import>
+  <make>gr_stellarstation.pdu_to_stream($type.size)</make>
 
   <param>
     <name>Output Type</name>

--- a/grc/stellarstation_pdu_to_stream.xml
+++ b/grc/stellarstation_pdu_to_stream.xml
@@ -2,7 +2,7 @@
 <block>
   <name>PDU to Stream</name>
   <key>stellarstation_pdu_to_stream</key>
-  <category>[stellarstation]</category>
+  <category>[stellarstation]/util</category>
   <import>from gnuradio import blocks</import>
   <import>import stellarstation</import>
   <make>stellarstation.pdu_to_stream($type.size)</make>

--- a/include/stellarstation/CMakeLists.txt
+++ b/include/stellarstation/CMakeLists.txt
@@ -23,5 +23,5 @@
 ########################################################################
 install(FILES
     api.h
-    DESTINATION include/stellarstation
+    api_source.h DESTINATION include/stellarstation
 )

--- a/include/stellarstation/CMakeLists.txt
+++ b/include/stellarstation/CMakeLists.txt
@@ -23,5 +23,6 @@
 ########################################################################
 install(FILES
     api.h
-    api_source.h DESTINATION include/stellarstation
+    api_source.h
+    pdu_to_stream.h DESTINATION include/stellarstation
 )

--- a/include/stellarstation/api.h
+++ b/include/stellarstation/api.h
@@ -26,9 +26,9 @@
 #include <gnuradio/attributes.h>
 
 #ifdef gnuradio_stellarstation_EXPORTS
-#  define STELLARSTATION_API __GR_ATTR_EXPORT
+#define STELLARSTATION_API __GR_ATTR_EXPORT
 #else
-#  define STELLARSTATION_API __GR_ATTR_IMPORT
+#define STELLARSTATION_API __GR_ATTR_IMPORT
 #endif
 
 #endif /* INCLUDED_STELLARSTATION_API_H */

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -1,69 +1,67 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc..
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef INCLUDED_STELLARSTATION_API_SOURCE_H
 #define INCLUDED_STELLARSTATION_API_SOURCE_H
 
-#include <stellarstation/api.h>
 #include <gnuradio/sync_block.h>
+#include <stellarstation/api.h>
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    /*!
-     * The Stellarstation API Source block is responsible for connecting to the
-     * Stellarstation API, receiving data, and propagating the received packets
-     * as PMTs for downstream blocks to consume. For users who are only expecting
-     * to receive one type of data from the satellite (IQ data, bitstream), you
-     * should use the dedicated hierarchical blocks (based on this block) for your
-     * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
-     * \ingroup stellarstation
-     *
-     */
-    class STELLARSTATION_API api_source : virtual public gr::block
-    {
-     public:
-      typedef boost::shared_ptr<api_source> sptr;
+/*!
+ * The Stellarstation API Source block is responsible for connecting to the
+ * Stellarstation API, receiving data, and propagating the received packets
+ * as PMTs for downstream blocks to consume. For users who are only expecting
+ * to receive one type of data from the satellite (IQ data, bitstream), you
+ * should use the dedicated hierarchical blocks (based on this block) for your
+ * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
+ * \ingroup stellarstation
+ *
+ */
+class STELLARSTATION_API api_source : virtual public gr::block {
+ public:
+  typedef boost::shared_ptr<api_source> sptr;
 
-      /**
-       * The Stellarstation API Source block is responsible for connecting to the
-       * Stellarstation API, receiving data, and propagating the received packets
-       * as PMTs for downstream blocks to consume. For users who are only expecting
-       * to receive one type of data from the satellite (IQ data, bitstream), you
-       * should use the dedicated hierarchical blocks (based on this block) for your
-       * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
-       *
-       * @param satellite_id Satellite ID to connect to
-       * @param stream_id Stream ID to connect to. Can be an empty string.
-       * @param key_path Path to JSON API Key
-       * @param root_cert_path Path to root certificate for development server.
-       * Leave blank for connecting to the real API
-       * @param api_url API URL to connect to.
-       */
-      static sptr make(const char *satellite_id, const char *stream_id,
-                       const char *key_path, const char *root_cert_path, const char *api_url);
-    };
+  /**
+   * The Stellarstation API Source block is responsible for connecting to the
+   * Stellarstation API, receiving data, and propagating the received packets
+   * as PMTs for downstream blocks to consume. For users who are only expecting
+   * to receive one type of data from the satellite (IQ data, bitstream), you
+   * should use the dedicated hierarchical blocks (based on this block) for your
+   * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
+   *
+   * @param satellite_id Satellite ID to connect to
+   * @param stream_id Stream ID to connect to. Can be an empty string.
+   * @param key_path Path to JSON API Key
+   * @param root_cert_path Path to root certificate for development server.
+   * Leave blank for connecting to the real API
+   * @param api_url API URL to connect to.
+   */
+  static sptr make(const char *satellite_id, const char *stream_id,
+                   const char *key_path, const char *root_cert_path,
+                   const char *api_url);
+};
 
-  } // namespace stellarstation
-} // namespace gr
+}  // namespace stellarstation
+}  // namespace gr
 
 #endif /* INCLUDED_STELLARSTATION_API_SOURCE_H */
-

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -1,0 +1,53 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc..
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_STELLARSTATION_API_SOURCE_H
+#define INCLUDED_STELLARSTATION_API_SOURCE_H
+
+#include <stellarstation/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace stellarstation {
+
+    /*!
+     * The Stellarstation API Source block is responsible for connecting to the
+     * Stellarstation API, receiving data, and propagating the received packets
+     * as PMTs for downstream blocks to consume. For users who are only expecting
+     * to receive one type of data from the satellite (IQ data, bitstream), you
+     * should use the dedicated hierarchical blocks (based on this block) for your
+     * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
+     * \ingroup stellarstation
+     *
+     */
+    class STELLARSTATION_API api_source : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<api_source> sptr;
+
+      static sptr make();
+    };
+
+  } // namespace stellarstation
+} // namespace gr
+
+#endif /* INCLUDED_STELLARSTATION_API_SOURCE_H */
+

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -43,7 +43,8 @@ namespace gr {
      public:
       typedef boost::shared_ptr<api_source> sptr;
 
-      static sptr make(const char *key_path, const char *root_cert_path);
+      static sptr make(const char *satellite_id, const char *stream_id,
+                       const char *key_path, const char *root_cert_path);
     };
 
   } // namespace stellarstation

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -44,7 +44,7 @@ namespace gr {
       typedef boost::shared_ptr<api_source> sptr;
 
       static sptr make(const char *satellite_id, const char *stream_id,
-                       const char *key_path, const char *root_cert_path);
+                       const char *key_path, const char *root_cert_path, const char *api_url);
     };
 
   } // namespace stellarstation

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -43,7 +43,7 @@ namespace gr {
      public:
       typedef boost::shared_ptr<api_source> sptr;
 
-      static sptr make(const char *key_path);
+      static sptr make(const char *key_path, const char *root_cert_path);
     };
 
   } // namespace stellarstation

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -43,7 +43,7 @@ namespace gr {
      public:
       typedef boost::shared_ptr<api_source> sptr;
 
-      static sptr make();
+      static sptr make(const char *key_path);
     };
 
   } // namespace stellarstation

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -43,6 +43,21 @@ namespace gr {
      public:
       typedef boost::shared_ptr<api_source> sptr;
 
+      /**
+       * The Stellarstation API Source block is responsible for connecting to the
+       * Stellarstation API, receiving data, and propagating the received packets
+       * as PMTs for downstream blocks to consume. For users who are only expecting
+       * to receive one type of data from the satellite (IQ data, bitstream), you
+       * should use the dedicated hierarchical blocks (based on this block) for your
+       * purpose e.g. Stellarstation IQ Source, Stellarstation bitstream source.
+       *
+       * @param satellite_id Satellite ID to connect to
+       * @param stream_id Stream ID to connect to. Can be an empty string.
+       * @param key_path Path to JSON API Key
+       * @param root_cert_path Path to root certificate for development server.
+       * Leave blank for connecting to the real API
+       * @param api_url API URL to connect to.
+       */
       static sptr make(const char *satellite_id, const char *stream_id,
                        const char *key_path, const char *root_cert_path, const char *api_url);
     };

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -56,9 +56,9 @@ class STELLARSTATION_API api_source : virtual public gr::block {
    * Leave blank when connecting to the real API
    * @param api_url API URL to connect to.
    */
-  static sptr make(const char *satellite_id, const char *stream_id,
-                   const char *key_path, const char *root_cert_path,
-                   const char *api_url);
+  static sptr make(std::string satellite_id, std::string stream_id,
+                   std::string key_path, std::string root_cert_path,
+                   std::string api_url);
 };
 
 }  // namespace stellarstation

--- a/include/stellarstation/api_source.h
+++ b/include/stellarstation/api_source.h
@@ -53,7 +53,7 @@ class STELLARSTATION_API api_source : virtual public gr::block {
    * @param stream_id Stream ID to connect to. Can be an empty string.
    * @param key_path Path to JSON API Key
    * @param root_cert_path Path to root certificate for development server.
-   * Leave blank for connecting to the real API
+   * Leave blank when connecting to the real API
    * @param api_url API URL to connect to.
    */
   static sptr make(const char *satellite_id, const char *stream_id,

--- a/include/stellarstation/pdu_to_stream.h
+++ b/include/stellarstation/pdu_to_stream.h
@@ -1,52 +1,49 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef INCLUDED_STELLARSTATION_PDU_TO_STREAM_H
 #define INCLUDED_STELLARSTATION_PDU_TO_STREAM_H
 
-#include <stellarstation/api.h>
 #include <gnuradio/sync_block.h>
+#include <stellarstation/api.h>
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    /*!
-     * This block converts a PDU into a stream. It is similar to the
-     * PDU to Tagged Stream block, however, it does not have a limit
-     * on the size of the PDU. (Stellarstation API usually returns ~1MB
-     * packets, while PDU to Tagged Stream is limited to ~32k bytes.) The
-     * design is mostly based on
-     * http://lists.ettus.com/pipermail/usrp-users_lists.ettus.com/2016-November/050626.html
-     * \ingroup stellarstation
-     *
-     */
-    class STELLARSTATION_API pdu_to_stream : virtual public gr::sync_block
-    {
-     public:
-      typedef boost::shared_ptr<pdu_to_stream> sptr;
-      static sptr make(size_t itemsize);
-    };
+/*!
+ * This block converts a PDU into a stream. It is similar to the
+ * PDU to Tagged Stream block, however, it does not have a limit
+ * on the size of the PDU. (Stellarstation API usually returns ~1MB
+ * packets, while PDU to Tagged Stream is limited to ~32k bytes.) The
+ * design is mostly based on
+ * http://lists.ettus.com/pipermail/usrp-users_lists.ettus.com/2016-November/050626.html
+ * \ingroup stellarstation
+ *
+ */
+class STELLARSTATION_API pdu_to_stream : virtual public gr::sync_block {
+ public:
+  typedef boost::shared_ptr<pdu_to_stream> sptr;
+  static sptr make(size_t itemsize);
+};
 
-  } // namespace stellarstation
-} // namespace gr
+}  // namespace stellarstation
+}  // namespace gr
 
 #endif /* INCLUDED_STELLARSTATION_PDU_TO_STREAM_H */
-

--- a/include/stellarstation/pdu_to_stream.h
+++ b/include/stellarstation/pdu_to_stream.h
@@ -1,0 +1,52 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_STELLARSTATION_PDU_TO_STREAM_H
+#define INCLUDED_STELLARSTATION_PDU_TO_STREAM_H
+
+#include <stellarstation/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace stellarstation {
+
+    /*!
+     * This block converts a PDU into a stream. It is similar to the
+     * PDU to Tagged Stream block, however, it does not have a limit
+     * on the size of the PDU. (Stellarstation API usually returns ~1MB
+     * packets, while PDU to Tagged Stream is limited to ~32k bytes.) The
+     * design is mostly based on
+     * http://lists.ettus.com/pipermail/usrp-users_lists.ettus.com/2016-November/050626.html
+     * \ingroup stellarstation
+     *
+     */
+    class STELLARSTATION_API pdu_to_stream : virtual public gr::sync_block
+    {
+     public:
+      typedef boost::shared_ptr<pdu_to_stream> sptr;
+      static sptr make(size_t itemsize);
+    };
+
+  } // namespace stellarstation
+} // namespace gr
+
+#endif /* INCLUDED_STELLARSTATION_PDU_TO_STREAM_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(gnuradio-stellarstation
   ${Boost_LIBRARIES}
   ${GNURADIO_ALL_LIBRARIES}
   ${_PROTOBUF_LIBPROTOBUF}
-  gRPC::grpc++_unsecure)
+  gRPC::grpc++)
 set_target_properties(gnuradio-stellarstation PROPERTIES DEFINE_SYMBOL "gnuradio_stellarstation_EXPORTS")
 
 if(APPLE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND stellarstation_sources
     api_source_impl.cc
     ${hw_proto_srcs}
     ${hw_grpc_srcs}
+    pdu_to_stream_impl.cc
 )
 
 set(stellarstation_sources "${stellarstation_sources}" PARENT_SCOPE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,11 +23,55 @@
 ########################################################################
 include(GrPlatform) #define LIB_SUFFIX
 
-include_directories(${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIR} ${Protobuf_INCLUDE_DIRS})
+
+# {Protobuf,PROTOBUF}_FOUND is defined based on find_package type ("MODULE" vs "CONFIG").
+# For "MODULE", the case has also changed between cmake 3.5 and 3.6.
+# We use the legacy uppercase version for *_LIBRARIES AND *_INCLUDE_DIRS variables
+# as newer cmake versions provide them too for backward compatibility.
+ if(Protobuf_FOUND OR PROTOBUF_FOUND)
+   if(TARGET protobuf::libprotobuf)
+     set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+   else()
+     set(_PROTOBUF_LIBPROTOBUF ${PROTOBUF_LIBRARIES})
+     include_directories(${PROTOBUF_INCLUDE_DIRS})
+   endif()
+   if(TARGET protobuf::protoc)
+     set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
+   else()
+     set(_PROTOBUF_PROTOC ${PROTOBUF_PROTOC_EXECUTABLE})
+   endif()
+ else()
+   message(WARNING "Failed to locate libprotobuf and protoc!")
+ endif()
+
+# gRPC C++ plugin
+get_target_property(gRPC_CPP_PLUGIN_EXECUTABLE gRPC::grpc_cpp_plugin
+  IMPORTED_LOCATION_RELEASE)
+
+get_filename_component(hw_proto "${stellarstation-api_SOURCE_DIR}/api/src/main/proto/stellarstation/api/v1/stellarstation.proto" ABSOLUTE)
+get_filename_component(hw_proto_path "${hw_proto}" PATH)
+
+protobuf_generate_cpp(hw_proto_srcs hw_proto_hdrs "${hw_proto}")
+set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/stellarstation.grpc.pb.cc")
+set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/stellarstation.grpc.pb.h")
+
+add_custom_command(
+       OUTPUT "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
+       COMMAND ${_PROTOBUF_PROTOC}
+       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" -I "${hw_proto_path}"
+         --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}"
+         "${hw_proto}"
+       DEPENDS "${hw_proto}")
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 link_directories(${Boost_LIBRARY_DIRS})
 
 list(APPEND stellarstation_sources
     api_source_impl.cc
+    ${hw_proto_srcs}
+    ${hw_grpc_srcs}
 )
 
 set(stellarstation_sources "${stellarstation_sources}" PARENT_SCOPE)
@@ -37,7 +81,11 @@ if(NOT stellarstation_sources)
 endif(NOT stellarstation_sources)
 
 add_library(gnuradio-stellarstation SHARED ${stellarstation_sources})
-target_link_libraries(gnuradio-stellarstation ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
+target_link_libraries(gnuradio-stellarstation
+  ${Boost_LIBRARIES}
+  ${GNURADIO_ALL_LIBRARIES}
+  ${_PROTOBUF_LIBPROTOBUF}
+  gRPC::grpc++_unsecure)
 set_target_properties(gnuradio-stellarstation PROPERTIES DEFINE_SYMBOL "gnuradio_stellarstation_EXPORTS")
 
 if(APPLE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIRS})
 
 list(APPEND stellarstation_sources
+    api_source_impl.cc
 )
 
 set(stellarstation_sources "${stellarstation_sources}" PARENT_SCOPE)

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -44,21 +44,25 @@ namespace gr {
   namespace stellarstation {
 
     api_source::sptr
-    api_source::make(const char *key_path, const char *root_cert_path)
+    api_source::make(const char *satellite_id, const char *stream_id,
+                     const char *key_path, const char *root_cert_path)
     {
       return gnuradio::get_initial_sptr
-        (new api_source_impl(key_path, root_cert_path));
+        (new api_source_impl(satellite_id, stream_id, key_path, root_cert_path));
     }
 
     /*
      * The private constructor
      */
-    api_source_impl::api_source_impl(const char *key_path, const char *root_cert_path)
+    api_source_impl::api_source_impl(const char *satellite_id, const char *stream_id,
+                                     const char *key_path, const char *root_cert_path)
       : gr::block("api_source",
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0)),
         port_(pmt::mp("out")),
         thread_(NULL),
+        satellite_id_(satellite_id),
+        stream_id_(stream_id),
         key_path_(key_path),
         root_cert_path_(root_cert_path)
     {
@@ -83,8 +87,8 @@ namespace gr {
       client_reader_writer_ = stub_->OpenSatelliteStream(&context_);
 
       SatelliteStreamRequest request;
-      // TODO: Don't hardcode this
-      request.set_satellite_id("5");
+      request.set_satellite_id(satellite_id_);
+      request.set_stream_id(stream_id_);
       client_reader_writer_->Write(request);
 
       thread_ = new std::thread(std::bind(&api_source_impl::readloop, this));

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -31,21 +31,22 @@ namespace gr {
   namespace stellarstation {
 
     api_source::sptr
-    api_source::make()
+    api_source::make(const char *key_path)
     {
       return gnuradio::get_initial_sptr
-        (new api_source_impl());
+        (new api_source_impl(key_path));
     }
 
     /*
      * The private constructor
      */
-    api_source_impl::api_source_impl()
+    api_source_impl::api_source_impl(const char *key_path)
       : gr::block("api_source",
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0)),
         port_(pmt::mp("out")),
-        thread_(NULL)
+        thread_(NULL),
+        key_path_(key_path)
     {
         message_port_register_out(port_);
     }
@@ -64,7 +65,7 @@ namespace gr {
     }
 
     void api_source_impl::readloop() {
-      std::cout << "Started loop" << std::endl;
+      std::cout << "Started loop " << key_path_ << std::endl;
     }
 
     /*

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -123,13 +123,13 @@ namespace gr {
 
             pmt::pmt_t dict_pmt(pmt::make_dict());
             dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("Downlink Frequency Hz"),
+                                     pmt::intern("DOWNLINK_FREQUENCY_HZ"),
                                      pmt::from_uint64(telem_resp.telemetry().downlink_frequency_hz()));
             dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("Framing"),
+                                     pmt::intern("FRAMING"),
                                      pmt::from_uint64(telem_resp.telemetry().framing()));
             dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("Frame header"),
+                                     pmt::intern("FRAME_HEADER"),
                                      pmt::make_blob(&telem_resp.telemetry().frame_header()[0],
                                                     telem_resp.telemetry().frame_header().size()));
 

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -149,7 +149,7 @@ void api_source_impl::readloop() {
   }
 }
 
-grpc::string api_source_impl::read_file_into_string(std::string filename) {
+static grpc::string read_file_into_string(std::string filename) {
   std::ifstream file(filename);
   std::stringstream stream;
   stream << file.rdbuf();

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -106,7 +106,9 @@ namespace gr {
       thread_->join();
 
       grpc::Status status = client_reader_writer_->Finish();
-      if (!status.ok()) std::cout << "rpc failed." << std::endl;
+      if (!status.ok()) {
+        std::cerr << "rpc failed. Error code: " << status.error_code() << std::endl << status.error_message() << status.error_details() << std::endl;
+      }
 
       std::cout << "Stopped successfully" << std::endl;
       return true;

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -43,21 +43,21 @@ using stellarstation::api::v1::ReceiveTelemetryResponse;
 namespace gr {
 namespace stellarstation {
 
-api_source::sptr api_source::make(const char *satellite_id,
-                                  const char *stream_id, const char *key_path,
-                                  const char *root_cert_path,
-                                  const char *api_url) {
+api_source::sptr api_source::make(std::string satellite_id,
+                                  std::string stream_id, std::string key_path,
+                                  std::string root_cert_path,
+                                  std::string api_url) {
   return gnuradio::get_initial_sptr(new api_source_impl(
-      satellite_id, stream_id, key_path, root_cert_path, api_url));
+      satellite_id, std::string(stream_id), key_path, root_cert_path, api_url));
 }
 
 /*
  * The private constructor
  */
-api_source_impl::api_source_impl(const char *satellite_id,
-                                 const char *stream_id, const char *key_path,
-                                 const char *root_cert_path,
-                                 const char *api_url)
+api_source_impl::api_source_impl(std::string satellite_id,
+                                 std::string stream_id, std::string key_path,
+                                 std::string root_cert_path,
+                                 std::string api_url)
     : gr::block("api_source", gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
       port_(pmt::mp("out")),
@@ -75,7 +75,7 @@ bool api_source_impl::start() {
   auto call_creds = grpc::ServiceAccountJWTAccessCredentials(json_key);
 
   grpc::SslCredentialsOptions opts;
-  if ((root_cert_path_ != NULL) && (root_cert_path_[0] != '\0')) {
+  if (!root_cert_path_.empty()) {
     grpc::string root_cert(read_file_into_string(root_cert_path_));
     opts.pem_root_certs = root_cert;
   }
@@ -149,7 +149,7 @@ void api_source_impl::readloop() {
   }
 }
 
-grpc::string api_source_impl::read_file_into_string(const char *filename) {
+grpc::string api_source_impl::read_file_into_string(std::string filename) {
   std::ifstream file(filename);
   std::stringstream stream;
   stream << file.rdbuf();

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -74,7 +74,6 @@ namespace gr {
       grpc::string json_key(read_file_into_string(key_path_));
       auto call_creds = grpc::ServiceAccountJWTAccessCredentials(json_key);
 
-      // TODO: This is probably wrong for the real stellarstation api
       grpc::SslCredentialsOptions opts;
       if ((root_cert_path_ != NULL) && (root_cert_path_[0] != '\0')) {
          grpc::string root_cert(read_file_into_string(root_cert_path_));
@@ -143,7 +142,6 @@ namespace gr {
     }
 
     grpc::string api_source_impl::read_file_into_string(const char *filename) {
-      std::cout << filename << std::endl;
       std::ifstream file(filename);
       std::stringstream stream;
       stream << file.rdbuf();

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc..
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -41,121 +41,121 @@ using stellarstation::api::v1::SatelliteStreamResponse;
 using stellarstation::api::v1::ReceiveTelemetryResponse;
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    api_source::sptr
-    api_source::make(const char *satellite_id, const char *stream_id,
-                     const char *key_path, const char *root_cert_path, const char *api_url)
-    {
-      return gnuradio::get_initial_sptr
-        (new api_source_impl(satellite_id, stream_id, key_path, root_cert_path, api_url));
+api_source::sptr api_source::make(const char *satellite_id,
+                                  const char *stream_id, const char *key_path,
+                                  const char *root_cert_path,
+                                  const char *api_url) {
+  return gnuradio::get_initial_sptr(new api_source_impl(
+      satellite_id, stream_id, key_path, root_cert_path, api_url));
+}
+
+/*
+ * The private constructor
+ */
+api_source_impl::api_source_impl(const char *satellite_id,
+                                 const char *stream_id, const char *key_path,
+                                 const char *root_cert_path,
+                                 const char *api_url)
+    : gr::block("api_source", gr::io_signature::make(0, 0, 0),
+                gr::io_signature::make(0, 0, 0)),
+      port_(pmt::mp("out")),
+      thread_(NULL),
+      satellite_id_(satellite_id),
+      stream_id_(stream_id),
+      key_path_(key_path),
+      root_cert_path_(root_cert_path),
+      api_url_(api_url) {
+  message_port_register_out(port_);
+}
+
+bool api_source_impl::start() {
+  grpc::string json_key(read_file_into_string(key_path_));
+  auto call_creds = grpc::ServiceAccountJWTAccessCredentials(json_key);
+
+  grpc::SslCredentialsOptions opts;
+  if ((root_cert_path_ != NULL) && (root_cert_path_[0] != '\0')) {
+    grpc::string root_cert(read_file_into_string(root_cert_path_));
+    opts.pem_root_certs = root_cert;
+  }
+
+  auto channel_creds = grpc::SslCredentials(opts);
+  auto composite_creds =
+      grpc::CompositeChannelCredentials(channel_creds, call_creds);
+  auto channel = grpc::CreateChannel(api_url_, composite_creds);
+  stub_ = StellarStationService::NewStub(channel);
+
+  client_reader_writer_ = stub_->OpenSatelliteStream(&context_);
+
+  SatelliteStreamRequest request;
+  request.set_satellite_id(satellite_id_);
+  request.set_stream_id(stream_id_);
+  client_reader_writer_->Write(request);
+
+  thread_ = new std::thread(std::bind(&api_source_impl::readloop, this));
+  return true;
+}
+
+bool api_source_impl::stop() {
+  std::cout << "Trying to stop" << std::endl;
+
+  // Signal the server it's time to stop
+  client_reader_writer_->WritesDone();
+
+  // Wait for the server to end the stream.
+  thread_->join();
+
+  grpc::Status status = client_reader_writer_->Finish();
+  if (!status.ok()) {
+    std::cerr << "rpc failed. Error code: " << status.error_code() << std::endl
+              << status.error_message() << status.error_details() << std::endl;
+  }
+
+  std::cout << "Stopped successfully" << std::endl;
+  return true;
+}
+
+void api_source_impl::readloop() {
+  SatelliteStreamResponse response;
+  while (client_reader_writer_->Read(&response)) {
+    std::cout << "STREAM ID" << response.stream_id() << std::endl;
+    if (response.has_receive_telemetry_response()) {
+      const ReceiveTelemetryResponse &telem_resp =
+          response.receive_telemetry_response();
+
+      pmt::pmt_t dict_pmt(pmt::make_dict());
+      dict_pmt = pmt::dict_add(
+          dict_pmt, pmt::intern("DOWNLINK_FREQUENCY_HZ"),
+          pmt::from_uint64(telem_resp.telemetry().downlink_frequency_hz()));
+      dict_pmt =
+          pmt::dict_add(dict_pmt, pmt::intern("FRAMING"),
+                        pmt::from_uint64(telem_resp.telemetry().framing()));
+      dict_pmt = pmt::dict_add(
+          dict_pmt, pmt::intern("FRAME_HEADER"),
+          pmt::make_blob(&telem_resp.telemetry().frame_header()[0],
+                         telem_resp.telemetry().frame_header().size()));
+
+      pmt::pmt_t vec_pmt(pmt::make_blob(&telem_resp.telemetry().data()[0],
+                                        telem_resp.telemetry().data().size()));
+      pmt::pmt_t pdu(pmt::cons(dict_pmt, vec_pmt));
+
+      message_port_pub(port_, pdu);
     }
+  }
+}
 
-    /*
-     * The private constructor
-     */
-    api_source_impl::api_source_impl(const char *satellite_id, const char *stream_id,
-                                     const char *key_path, const char *root_cert_path, const char *api_url)
-      : gr::block("api_source",
-              gr::io_signature::make(0, 0, 0),
-              gr::io_signature::make(0, 0, 0)),
-        port_(pmt::mp("out")),
-        thread_(NULL),
-        satellite_id_(satellite_id),
-        stream_id_(stream_id),
-        key_path_(key_path),
-        root_cert_path_(root_cert_path),
-        api_url_(api_url)
-    {
-        message_port_register_out(port_);
-    }
+grpc::string api_source_impl::read_file_into_string(const char *filename) {
+  std::ifstream file(filename);
+  std::stringstream stream;
+  stream << file.rdbuf();
+  return stream.str();
+}
 
-    bool api_source_impl::start() {
-      grpc::string json_key(read_file_into_string(key_path_));
-      auto call_creds = grpc::ServiceAccountJWTAccessCredentials(json_key);
+/*
+ * Our virtual destructor.
+ */
+api_source_impl::~api_source_impl() {}
 
-      grpc::SslCredentialsOptions opts;
-      if ((root_cert_path_ != NULL) && (root_cert_path_[0] != '\0')) {
-         grpc::string root_cert(read_file_into_string(root_cert_path_));
-         opts.pem_root_certs = root_cert;
-      }
-
-      auto channel_creds = grpc::SslCredentials(opts);
-      auto composite_creds = grpc::CompositeChannelCredentials(channel_creds, call_creds);
-      auto channel = grpc::CreateChannel(api_url_, composite_creds);
-      stub_  = StellarStationService::NewStub(channel);
-
-      client_reader_writer_ = stub_->OpenSatelliteStream(&context_);
-
-      SatelliteStreamRequest request;
-      request.set_satellite_id(satellite_id_);
-      request.set_stream_id(stream_id_);
-      client_reader_writer_->Write(request);
-
-      thread_ = new std::thread(std::bind(&api_source_impl::readloop, this));
-      return true;
-    }
-
-    bool api_source_impl::stop() {
-      std::cout << "Trying to stop" << std::endl;
-
-      // Signal the server it's time to stop
-      client_reader_writer_->WritesDone();
-
-      // Wait for the server to end the stream.
-      thread_->join();
-
-      grpc::Status status = client_reader_writer_->Finish();
-      if (!status.ok()) {
-        std::cerr << "rpc failed. Error code: " << status.error_code() << std::endl << status.error_message() << status.error_details() << std::endl;
-      }
-
-      std::cout << "Stopped successfully" << std::endl;
-      return true;
-    }
-
-    void api_source_impl::readloop() {
-
-      SatelliteStreamResponse response;
-      while (client_reader_writer_->Read(&response)) {
-        std::cout << "STREAM ID" << response.stream_id() << std::endl;
-        if (response.has_receive_telemetry_response()) {
-            const ReceiveTelemetryResponse &telem_resp = response.receive_telemetry_response();
-
-            pmt::pmt_t dict_pmt(pmt::make_dict());
-            dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("DOWNLINK_FREQUENCY_HZ"),
-                                     pmt::from_uint64(telem_resp.telemetry().downlink_frequency_hz()));
-            dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("FRAMING"),
-                                     pmt::from_uint64(telem_resp.telemetry().framing()));
-            dict_pmt = pmt::dict_add(dict_pmt,
-                                     pmt::intern("FRAME_HEADER"),
-                                     pmt::make_blob(&telem_resp.telemetry().frame_header()[0],
-                                                    telem_resp.telemetry().frame_header().size()));
-
-            pmt::pmt_t vec_pmt(pmt::make_blob(&telem_resp.telemetry().data()[0],
-                               telem_resp.telemetry().data().size()));
-            pmt::pmt_t pdu(pmt::cons(dict_pmt, vec_pmt));
-
-            message_port_pub(port_, pdu);
-        }
-      }
-    }
-
-    grpc::string api_source_impl::read_file_into_string(const char *filename) {
-      std::ifstream file(filename);
-      std::stringstream stream;
-      stream << file.rdbuf();
-      return stream.str();
-    }
-
-    /*
-     * Our virtual destructor.
-     */
-    api_source_impl::~api_source_impl()
-    {
-    }
-
-  } /* namespace stellarstation */
+} /* namespace stellarstation */
 } /* namespace gr */

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -98,7 +98,7 @@ bool api_source_impl::start() {
 }
 
 bool api_source_impl::stop() {
-  std::cout << "Trying to stop" << std::endl;
+  GR_LOG_DEBUG(d_logger, "Trying to stop");
 
   // Signal the server it's time to stop
   client_reader_writer_->WritesDone();
@@ -113,8 +113,9 @@ bool api_source_impl::stop() {
                      status.error_code() % status.error_message() %
                      status.error_details());
   }
+  stub_.reset(NULL);  // Explicitly close the gRPC connection by deleting stub
 
-  std::cout << "Stopped successfully" << std::endl;
+  GR_LOG_DEBUG(d_logger, "Stopped successfully");
   return true;
 }
 

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -99,8 +99,17 @@ namespace gr {
     }
 
     bool api_source_impl::stop() {
-      // TODO: End things here
+      std::cout << "Trying to stop" << std::endl;
+
+      // Signal the server it's time to stop
+      client_reader_writer_->WritesDone();
+
+      // Wait for the server to end the stream.
       thread_->join();
+
+      grpc::Status status = client_reader_writer_->Finish();
+      if (!status.ok()) std::cout << "rpc failed." << std::endl;
+
       std::cout << "Stopped successfully" << std::endl;
       return true;
     }

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -108,8 +108,10 @@ bool api_source_impl::stop() {
 
   grpc::Status status = client_reader_writer_->Finish();
   if (!status.ok()) {
-    std::cerr << "rpc failed. Error code: " << status.error_code() << std::endl
-              << status.error_message() << status.error_details() << std::endl;
+    GR_LOG_ERROR(d_logger,
+                 boost::format("rpc failed. error code:  %1%\n%2%\n%3%") %
+                     status.error_code() % status.error_message() %
+                     status.error_details());
   }
 
   std::cout << "Stopped successfully" << std::endl;
@@ -119,7 +121,9 @@ bool api_source_impl::stop() {
 void api_source_impl::readloop() {
   SatelliteStreamResponse response;
   while (client_reader_writer_->Read(&response)) {
-    std::cout << "STREAM ID" << response.stream_id() << std::endl;
+    GR_LOG_DEBUG(
+        d_logger,
+        boost::format("Packet received. Stream ID: %1%") % response.stream_id())
     if (response.has_receive_telemetry_response()) {
       const ReceiveTelemetryResponse &telem_resp =
           response.receive_telemetry_response();

--- a/lib/api_source_impl.cc
+++ b/lib/api_source_impl.cc
@@ -1,0 +1,79 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc..
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "api_source_impl.h"
+
+#include <iostream>
+
+namespace gr {
+  namespace stellarstation {
+
+    api_source::sptr
+    api_source::make()
+    {
+      return gnuradio::get_initial_sptr
+        (new api_source_impl());
+    }
+
+    /*
+     * The private constructor
+     */
+    api_source_impl::api_source_impl()
+      : gr::block("api_source",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(0, 0, 0)),
+        port_(pmt::mp("out")),
+        thread_(NULL)
+    {
+        message_port_register_out(port_);
+    }
+
+    bool api_source_impl::start() {
+      // TODO: Start things here
+      thread_ = new std::thread(std::bind(&api_source_impl::readloop, this));
+      return true;
+    }
+
+    bool api_source_impl::stop() {
+      // TODO: End things here
+      thread_->join();
+      std::cout << "Stopped successfully" << std::endl;
+      return true;
+    }
+
+    void api_source_impl::readloop() {
+      std::cout << "Started loop" << std::endl;
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    api_source_impl::~api_source_impl()
+    {
+    }
+
+  } /* namespace stellarstation */
+} /* namespace gr */
+

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -35,9 +35,10 @@ namespace gr {
 
       std::thread *thread_;
       const pmt::pmt_t port_;
+      const char *key_path_;
 
      public:
-      api_source_impl();
+      api_source_impl(const char *key_path);
       ~api_source_impl();
 
       bool start();

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -38,16 +38,18 @@ namespace gr {
     {
      private:
       void readloop();
+      grpc::string read_file_into_string(const char *filename);
 
       std::thread *thread_;
       const pmt::pmt_t port_;
       const char *key_path_;
+      const char *root_cert_path_;
       grpc::ClientContext context_;
       std::unique_ptr<StellarStationService::Stub> stub_;
       std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest, SatelliteStreamResponse> > client_reader_writer_;
 
      public:
-      api_source_impl(const char *key_path);
+      api_source_impl(const char *key_path, const char *root_cert_path);
       ~api_source_impl();
 
       bool start();

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -25,6 +25,10 @@
 
 #include <thread>
 
+#include "stellarstation.grpc.pb.h"
+
+using stellarstation::api::v1::StellarStationService;
+
 namespace gr {
   namespace stellarstation {
 
@@ -36,6 +40,7 @@ namespace gr {
       std::thread *thread_;
       const pmt::pmt_t port_;
       const char *key_path_;
+      std::unique_ptr<StellarStationService::Stub> stub_;
 
      public:
       api_source_impl(const char *key_path);

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -35,6 +35,15 @@ namespace gr {
 namespace stellarstation {
 
 class api_source_impl : public api_source {
+ public:
+  api_source_impl(const char *satellite_id, const char *stream_id,
+                  const char *key_path, const char *root_cert_path,
+                  const char *api_url);
+  ~api_source_impl();
+
+  bool start();
+  bool stop();
+
  private:
   void readloop();
   grpc::string read_file_into_string(const char *filename);
@@ -51,15 +60,6 @@ class api_source_impl : public api_source {
   std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest,
                                            SatelliteStreamResponse> >
       client_reader_writer_;
-
- public:
-  api_source_impl(const char *satellite_id, const char *stream_id,
-                  const char *key_path, const char *root_cert_path,
-                  const char *api_url);
-  ~api_source_impl();
-
-  bool start();
-  bool stop();
 };
 
 }  // namespace stellarstation

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -46,13 +46,14 @@ namespace gr {
       const char *stream_id_;
       const char *key_path_;
       const char *root_cert_path_;
+      const char *api_url_;
       grpc::ClientContext context_;
       std::unique_ptr<StellarStationService::Stub> stub_;
       std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest, SatelliteStreamResponse> > client_reader_writer_;
 
      public:
       api_source_impl(const char *satellite_id, const char *stream_id,
-                      const char *key_path, const char *root_cert_path);
+                      const char *key_path, const char *root_cert_path, const char *api_url);
       ~api_source_impl();
 
       bool start();

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc..
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -32,36 +32,37 @@ using stellarstation::api::v1::SatelliteStreamRequest;
 using stellarstation::api::v1::SatelliteStreamResponse;
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    class api_source_impl : public api_source
-    {
-     private:
-      void readloop();
-      grpc::string read_file_into_string(const char *filename);
+class api_source_impl : public api_source {
+ private:
+  void readloop();
+  grpc::string read_file_into_string(const char *filename);
 
-      std::thread *thread_;
-      const pmt::pmt_t port_;
-      const char *satellite_id_;
-      const char *stream_id_;
-      const char *key_path_;
-      const char *root_cert_path_;
-      const char *api_url_;
-      grpc::ClientContext context_;
-      std::unique_ptr<StellarStationService::Stub> stub_;
-      std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest, SatelliteStreamResponse> > client_reader_writer_;
+  std::thread *thread_;
+  const pmt::pmt_t port_;
+  const char *satellite_id_;
+  const char *stream_id_;
+  const char *key_path_;
+  const char *root_cert_path_;
+  const char *api_url_;
+  grpc::ClientContext context_;
+  std::unique_ptr<StellarStationService::Stub> stub_;
+  std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest,
+                                           SatelliteStreamResponse> >
+      client_reader_writer_;
 
-     public:
-      api_source_impl(const char *satellite_id, const char *stream_id,
-                      const char *key_path, const char *root_cert_path, const char *api_url);
-      ~api_source_impl();
+ public:
+  api_source_impl(const char *satellite_id, const char *stream_id,
+                  const char *key_path, const char *root_cert_path,
+                  const char *api_url);
+  ~api_source_impl();
 
-      bool start();
-      bool stop();
-    };
+  bool start();
+  bool stop();
+};
 
-  } // namespace stellarstation
-} // namespace gr
+}  // namespace stellarstation
+}  // namespace gr
 
 #endif /* INCLUDED_STELLARSTATION_API_SOURCE_IMPL_H */
-

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -46,7 +46,6 @@ class api_source_impl : public api_source {
 
  private:
   void readloop();
-  grpc::string read_file_into_string(std::string filename);
 
   std::thread *thread_;
   const pmt::pmt_t port_;
@@ -61,6 +60,8 @@ class api_source_impl : public api_source {
                                            SatelliteStreamResponse> >
       client_reader_writer_;
 };
+
+static grpc::string read_file_into_string(std::string filename);
 
 }  // namespace stellarstation
 }  // namespace gr

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -1,0 +1,51 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc..
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_STELLARSTATION_API_SOURCE_IMPL_H
+#define INCLUDED_STELLARSTATION_API_SOURCE_IMPL_H
+
+#include <stellarstation/api_source.h>
+
+#include <thread>
+
+namespace gr {
+  namespace stellarstation {
+
+    class api_source_impl : public api_source
+    {
+     private:
+      void readloop();
+
+      std::thread *thread_;
+      const pmt::pmt_t port_;
+
+     public:
+      api_source_impl();
+      ~api_source_impl();
+
+      bool start();
+      bool stop();
+    };
+
+  } // namespace stellarstation
+} // namespace gr
+
+#endif /* INCLUDED_STELLARSTATION_API_SOURCE_IMPL_H */
+

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -36,9 +36,9 @@ namespace stellarstation {
 
 class api_source_impl : public api_source {
  public:
-  api_source_impl(const char *satellite_id, const char *stream_id,
-                  const char *key_path, const char *root_cert_path,
-                  const char *api_url);
+  api_source_impl(std::string satellite_id, std::string stream_id,
+                  std::string key_path, std::string root_cert_path,
+                  std::string api_url);
   ~api_source_impl();
 
   bool start();
@@ -46,15 +46,15 @@ class api_source_impl : public api_source {
 
  private:
   void readloop();
-  grpc::string read_file_into_string(const char *filename);
+  grpc::string read_file_into_string(std::string filename);
 
   std::thread *thread_;
   const pmt::pmt_t port_;
-  const char *satellite_id_;
-  const char *stream_id_;
-  const char *key_path_;
-  const char *root_cert_path_;
-  const char *api_url_;
+  std::string satellite_id_;
+  std::string stream_id_;
+  std::string key_path_;
+  std::string root_cert_path_;
+  std::string api_url_;
   grpc::ClientContext context_;
   std::unique_ptr<StellarStationService::Stub> stub_;
   std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest,

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -28,6 +28,8 @@
 #include "stellarstation.grpc.pb.h"
 
 using stellarstation::api::v1::StellarStationService;
+using stellarstation::api::v1::SatelliteStreamRequest;
+using stellarstation::api::v1::SatelliteStreamResponse;
 
 namespace gr {
   namespace stellarstation {
@@ -40,7 +42,9 @@ namespace gr {
       std::thread *thread_;
       const pmt::pmt_t port_;
       const char *key_path_;
+      grpc::ClientContext context_;
       std::unique_ptr<StellarStationService::Stub> stub_;
+      std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest, SatelliteStreamResponse> > client_reader_writer_;
 
      public:
       api_source_impl(const char *key_path);

--- a/lib/api_source_impl.h
+++ b/lib/api_source_impl.h
@@ -42,6 +42,8 @@ namespace gr {
 
       std::thread *thread_;
       const pmt::pmt_t port_;
+      const char *satellite_id_;
+      const char *stream_id_;
       const char *key_path_;
       const char *root_cert_path_;
       grpc::ClientContext context_;
@@ -49,7 +51,8 @@ namespace gr {
       std::shared_ptr<grpc::ClientReaderWriter<SatelliteStreamRequest, SatelliteStreamResponse> > client_reader_writer_;
 
      public:
-      api_source_impl(const char *key_path, const char *root_cert_path);
+      api_source_impl(const char *satellite_id, const char *stream_id,
+                      const char *key_path, const char *root_cert_path);
       ~api_source_impl();
 
       bool start();

--- a/lib/pdu_to_stream_impl.cc
+++ b/lib/pdu_to_stream_impl.cc
@@ -1,0 +1,104 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "pdu_to_stream_impl.h"
+
+#include <algorithm>
+
+namespace gr {
+  namespace stellarstation {
+
+    pdu_to_stream::sptr
+    pdu_to_stream::make(size_t itemsize)
+    {
+      return gnuradio::get_initial_sptr
+        (new pdu_to_stream_impl(itemsize));
+    }
+
+    /*
+     * The private constructor
+     */
+    pdu_to_stream_impl::pdu_to_stream_impl(size_t itemsize)
+      : gr::sync_block("pdu_to_stream",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(1, 1, itemsize)),
+        current_pdu_(pmt::pmt_t()),
+        itemsize_(itemsize),
+        current_buffer_position_(0)
+    {
+      message_port_register_in(pmt::mp("pdu"));
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    pdu_to_stream_impl::~pdu_to_stream_impl()
+    {
+    }
+
+    int
+    pdu_to_stream_impl::work (int noutput_items,
+                               gr_vector_const_void_star &input_items,
+                               gr_vector_void_star &output_items)
+    {
+      if(current_pdu_.get() == NULL) {
+        // We are not currently processing a PDU
+        pmt::pmt_t msg(delete_head_blocking(pmt::mp("pdu"), 100));
+        if (msg.get() == NULL) {
+          return 0;
+        }
+
+        if (!pmt::is_pair(msg)) {
+          throw std::runtime_error("received a malformed pdu message");
+        }
+
+        current_pdu_ = msg;
+      }
+
+      pmt::pmt_t pmt_vect = pmt::cdr(current_pdu_);
+      int total_pdu_items = pmt::blob_length(pmt_vect)/itemsize_;
+      int available_items = total_pdu_items - current_buffer_position_;
+      int items_to_transfer = std::min(available_items, noutput_items);
+
+      size_t io(0);
+      const uint8_t* ptr = (const uint8_t *) pmt::uniform_vector_elements(pmt_vect, io);
+      uint8_t *out = (uint8_t *) output_items[0];
+
+      memcpy(out, ptr + current_buffer_position_*itemsize_, items_to_transfer*itemsize_);
+
+      current_buffer_position_ += items_to_transfer;
+
+      if (current_buffer_position_ == total_pdu_items) {
+        // PDU has been fully streamed out. We can now process another PDU.
+        current_buffer_position_ = 0;
+        current_pdu_ = pmt::pmt_t();
+      }
+
+      // Tell runtime system how many output items we produced.
+      return items_to_transfer;
+    }
+
+  } /* namespace stellarstation */
+} /* namespace gr */

--- a/lib/pdu_to_stream_impl.cc
+++ b/lib/pdu_to_stream_impl.cc
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,77 +28,70 @@
 #include <algorithm>
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    pdu_to_stream::sptr
-    pdu_to_stream::make(size_t itemsize)
-    {
-      return gnuradio::get_initial_sptr
-        (new pdu_to_stream_impl(itemsize));
+pdu_to_stream::sptr pdu_to_stream::make(size_t itemsize) {
+  return gnuradio::get_initial_sptr(new pdu_to_stream_impl(itemsize));
+}
+
+/*
+ * The private constructor
+ */
+pdu_to_stream_impl::pdu_to_stream_impl(size_t itemsize)
+    : gr::sync_block("pdu_to_stream", gr::io_signature::make(0, 0, 0),
+                     gr::io_signature::make(1, 1, itemsize)),
+      current_pdu_(pmt::pmt_t()),
+      itemsize_(itemsize),
+      current_buffer_position_(0) {
+  message_port_register_in(pmt::mp("pdu"));
+}
+
+/*
+ * Our virtual destructor.
+ */
+pdu_to_stream_impl::~pdu_to_stream_impl() {}
+
+int pdu_to_stream_impl::work(int noutput_items,
+                             gr_vector_const_void_star &input_items,
+                             gr_vector_void_star &output_items) {
+  if (current_pdu_.get() == NULL) {
+    // We are not currently processing a PDU
+    pmt::pmt_t msg(delete_head_blocking(pmt::mp("pdu"), 100));
+    if (msg.get() == NULL) {
+      return 0;
     }
 
-    /*
-     * The private constructor
-     */
-    pdu_to_stream_impl::pdu_to_stream_impl(size_t itemsize)
-      : gr::sync_block("pdu_to_stream",
-              gr::io_signature::make(0, 0, 0),
-              gr::io_signature::make(1, 1, itemsize)),
-        current_pdu_(pmt::pmt_t()),
-        itemsize_(itemsize),
-        current_buffer_position_(0)
-    {
-      message_port_register_in(pmt::mp("pdu"));
+    if (!pmt::is_pair(msg)) {
+      throw std::runtime_error("received a malformed pdu message");
     }
 
-    /*
-     * Our virtual destructor.
-     */
-    pdu_to_stream_impl::~pdu_to_stream_impl()
-    {
-    }
+    current_pdu_ = msg;
+  }
 
-    int
-    pdu_to_stream_impl::work (int noutput_items,
-                               gr_vector_const_void_star &input_items,
-                               gr_vector_void_star &output_items)
-    {
-      if(current_pdu_.get() == NULL) {
-        // We are not currently processing a PDU
-        pmt::pmt_t msg(delete_head_blocking(pmt::mp("pdu"), 100));
-        if (msg.get() == NULL) {
-          return 0;
-        }
+  pmt::pmt_t pmt_vect = pmt::cdr(current_pdu_);
+  int total_pdu_items = pmt::blob_length(pmt_vect) / itemsize_;
+  int available_items = total_pdu_items - current_buffer_position_;
+  int items_to_transfer = std::min(available_items, noutput_items);
 
-        if (!pmt::is_pair(msg)) {
-          throw std::runtime_error("received a malformed pdu message");
-        }
+  size_t io(0);
+  const uint8_t *ptr =
+      (const uint8_t *)pmt::uniform_vector_elements(pmt_vect, io);
+  uint8_t *out = (uint8_t *)output_items[0];
 
-        current_pdu_ = msg;
-      }
+  memcpy(out, ptr + current_buffer_position_ * itemsize_,
+         items_to_transfer * itemsize_);
 
-      pmt::pmt_t pmt_vect = pmt::cdr(current_pdu_);
-      int total_pdu_items = pmt::blob_length(pmt_vect)/itemsize_;
-      int available_items = total_pdu_items - current_buffer_position_;
-      int items_to_transfer = std::min(available_items, noutput_items);
+  current_buffer_position_ += items_to_transfer;
 
-      size_t io(0);
-      const uint8_t* ptr = (const uint8_t *) pmt::uniform_vector_elements(pmt_vect, io);
-      uint8_t *out = (uint8_t *) output_items[0];
+  if (current_buffer_position_ == total_pdu_items) {
+    // PDU has been fully streamed out. We can now process another PDU.
+    current_buffer_position_ = 0;
+    current_pdu_ = pmt::pmt_t();
+  }
 
-      memcpy(out, ptr + current_buffer_position_*itemsize_, items_to_transfer*itemsize_);
+  // Tell runtime system how many output items we produced.
+  return items_to_transfer;
+}
 
-      current_buffer_position_ += items_to_transfer;
-
-      if (current_buffer_position_ == total_pdu_items) {
-        // PDU has been fully streamed out. We can now process another PDU.
-        current_buffer_position_ = 0;
-        current_pdu_ = pmt::pmt_t();
-      }
-
-      // Tell runtime system how many output items we produced.
-      return items_to_transfer;
-    }
-
-  } /* namespace stellarstation */
+} /* namespace stellarstation */
 } /* namespace gr */

--- a/lib/pdu_to_stream_impl.h
+++ b/lib/pdu_to_stream_impl.h
@@ -27,17 +27,17 @@ namespace gr {
 namespace stellarstation {
 
 class pdu_to_stream_impl : public pdu_to_stream {
- private:
-  pmt::pmt_t current_pdu_;
-  size_t itemsize_;
-  int current_buffer_position_;
-
  public:
   pdu_to_stream_impl(size_t itemsize);
   ~pdu_to_stream_impl();
 
   int work(int noutput_items, gr_vector_const_void_star &input_items,
            gr_vector_void_star &output_items);
+
+ private:
+  pmt::pmt_t current_pdu_;
+  size_t itemsize_;
+  int current_buffer_position_;
 };
 
 }  // namespace stellarstation

--- a/lib/pdu_to_stream_impl.h
+++ b/lib/pdu_to_stream_impl.h
@@ -1,0 +1,49 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2018 Infostellar, Inc.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_STELLARSTATION_PDU_TO_STREAM_IMPL_H
+#define INCLUDED_STELLARSTATION_PDU_TO_STREAM_IMPL_H
+
+#include <stellarstation/pdu_to_stream.h>
+
+namespace gr {
+  namespace stellarstation {
+
+    class pdu_to_stream_impl : public pdu_to_stream
+    {
+     private:
+      pmt::pmt_t current_pdu_;
+      size_t itemsize_;
+      int current_buffer_position_;
+
+     public:
+      pdu_to_stream_impl(size_t itemsize);
+      ~pdu_to_stream_impl();
+
+      int work(int noutput_items,
+                       			   gr_vector_const_void_star &input_items,
+                       			   gr_vector_void_star &output_items);
+    };
+
+  } // namespace stellarstation
+} // namespace gr
+
+#endif /* INCLUDED_STELLARSTATION_PDU_TO_STREAM_IMPL_H */
+

--- a/lib/pdu_to_stream_impl.h
+++ b/lib/pdu_to_stream_impl.h
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2018 Infostellar, Inc.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -24,26 +24,23 @@
 #include <stellarstation/pdu_to_stream.h>
 
 namespace gr {
-  namespace stellarstation {
+namespace stellarstation {
 
-    class pdu_to_stream_impl : public pdu_to_stream
-    {
-     private:
-      pmt::pmt_t current_pdu_;
-      size_t itemsize_;
-      int current_buffer_position_;
+class pdu_to_stream_impl : public pdu_to_stream {
+ private:
+  pmt::pmt_t current_pdu_;
+  size_t itemsize_;
+  int current_buffer_position_;
 
-     public:
-      pdu_to_stream_impl(size_t itemsize);
-      ~pdu_to_stream_impl();
+ public:
+  pdu_to_stream_impl(size_t itemsize);
+  ~pdu_to_stream_impl();
 
-      int work(int noutput_items,
-                       			   gr_vector_const_void_star &input_items,
-                       			   gr_vector_void_star &output_items);
-    };
+  int work(int noutput_items, gr_vector_const_void_star &input_items,
+           gr_vector_void_star &output_items);
+};
 
-  } // namespace stellarstation
-} // namespace gr
+}  // namespace stellarstation
+}  // namespace gr
 
 #endif /* INCLUDED_STELLARSTATION_PDU_TO_STREAM_IMPL_H */
-

--- a/lib/qa_stellarstation.cc
+++ b/lib/qa_stellarstation.cc
@@ -28,9 +28,7 @@
 
 #include "qa_stellarstation.h"
 
-CppUnit::TestSuite *
-qa_stellarstation::suite()
-{
+CppUnit::TestSuite *qa_stellarstation::suite() {
   CppUnit::TestSuite *s = new CppUnit::TestSuite("stellarstation");
 
   return s;

--- a/lib/qa_stellarstation.h
+++ b/lib/qa_stellarstation.h
@@ -24,13 +24,12 @@
 #ifndef _QA_STELLARSTATION_H_
 #define _QA_STELLARSTATION_H_
 
-#include <gnuradio/attributes.h>
 #include <cppunit/TestSuite.h>
+#include <gnuradio/attributes.h>
 
 //! collect all the tests for the gr-filter directory
 
-class __GR_ATTR_EXPORT qa_stellarstation
-{
+class __GR_ATTR_EXPORT qa_stellarstation {
  public:
   //! return suite of tests for all of gr-filter directory
   static CppUnit::TestSuite *suite();

--- a/lib/test_stellarstation.cc
+++ b/lib/test_stellarstation.cc
@@ -29,16 +29,15 @@
 #include <cppunit/XmlOutputter.h>
 
 #include <gnuradio/unittests.h>
-#include "qa_stellarstation.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include "qa_stellarstation.h"
 
-int
-main (int argc, char **argv)
-{
+int main(int argc, char **argv) {
   CppUnit::TextTestRunner runner;
   std::ofstream xmlfile(get_unittest_path("stellarstation.xml").c_str());
-  CppUnit::XmlOutputter *xmlout = new CppUnit::XmlOutputter(&runner.result(), xmlfile);
+  CppUnit::XmlOutputter *xmlout =
+      new CppUnit::XmlOutputter(&runner.result(), xmlfile);
 
   runner.addTest(qa_stellarstation::suite());
   runner.setOutputter(xmlout);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -33,7 +33,7 @@ GR_PYTHON_INSTALL(
     FILES
     __init__.py
     iq_source.py
-    bitstream_source.py DESTINATION ${GR_PYTHON_DIR}/stellarstation
+    bitstream_source.py DESTINATION ${GR_PYTHON_DIR}/gr_stellarstation
 )
 
 ########################################################################

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 GR_PYTHON_INSTALL(
     FILES
     __init__.py
-    DESTINATION ${GR_PYTHON_DIR}/stellarstation
+    iq_source.py DESTINATION ${GR_PYTHON_DIR}/stellarstation
 )
 
 ########################################################################

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,7 +32,8 @@ endif()
 GR_PYTHON_INSTALL(
     FILES
     __init__.py
-    iq_source.py DESTINATION ${GR_PYTHON_DIR}/stellarstation
+    iq_source.py
+    bitstream_source.py DESTINATION ${GR_PYTHON_DIR}/stellarstation
 )
 
 ########################################################################

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -32,4 +32,5 @@ except ImportError:
 
 # import any pure python here
 from iq_source import iq_source
+from bitstream_source import bitstream_source
 #

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -31,4 +31,5 @@ except ImportError:
 	pass
 
 # import any pure python here
+from iq_source import iq_source
 #

--- a/python/bitstream_source.py
+++ b/python/bitstream_source.py
@@ -22,7 +22,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 import pmt
-from stellarstation import stellarstation_swig
+from gr_stellarstation import stellarstation_swig
 
 class bitstream_source(gr.hier_block2):
     """

--- a/python/bitstream_source.py
+++ b/python/bitstream_source.py
@@ -30,6 +30,14 @@ class bitstream_source(gr.hier_block2):
     using the Stellarstation API.
     """
     def __init__(self, satellite_id, stream_id, key_path, root_cert_path="", api_url="api.stellarstation.com"):
+        """
+        :param satellite_id: Satellite ID to connect to
+        :param stream_id: Stream ID to connect to. Can be an empty string.
+        :param key_path: Path to JSON API Key
+        :param root_cert_path: Path to root certificate for development server.
+        Leave blank for connecting to the real API
+        :param api_url: API URL to connect to.
+        """
         gr.hier_block2.__init__(self,
                                 "iq_source",
                                 gr.io_signature(0, 0, 0),  # Input signature

--- a/python/bitstream_source.py
+++ b/python/bitstream_source.py
@@ -35,7 +35,7 @@ class bitstream_source(gr.hier_block2):
         :param stream_id: Stream ID to connect to. Can be an empty string.
         :param key_path: Path to JSON API Key
         :param root_cert_path: Path to root certificate for development server.
-        Leave blank for connecting to the real API
+        Leave blank when connecting to the real API
         :param api_url: API URL to connect to.
         """
         gr.hier_block2.__init__(self,

--- a/python/bitstream_source.py
+++ b/python/bitstream_source.py
@@ -24,22 +24,21 @@ from gnuradio import blocks
 import pmt
 from stellarstation import stellarstation_swig
 
-
-class iq_source(gr.hier_block2):
+class bitstream_source(gr.hier_block2):
     """
-    This hierarchical block contains a block for streaming IQ data from a satellite
+    This hierarchical block contains a block for streaming bitstream data from a satellite
     using the Stellarstation API.
     """
     def __init__(self, satellite_id, stream_id, key_path, root_cert_path="", api_url="api.stellarstation.com"):
         gr.hier_block2.__init__(self,
-            "iq_source",
-            gr.io_signature(0, 0, 0),  # Input signature
-            gr.io_signature(1, 1, gr.sizeof_gr_complex))  # Output signature
+                                "iq_source",
+                                gr.io_signature(0, 0, 0),  # Input signature
+                                gr.io_signature(1, 1, gr.sizeof_char))  # Output signature
 
         # Define blocks and connect them
         api_source = stellarstation_swig.api_source(satellite_id, stream_id, key_path, root_cert_path, api_url)
-        pdu_filter = blocks.pdu_filter(pmt.intern("FRAMING"), pmt.from_uint64(2))  # Parse only packets with IQ Framing
-        pdu_to_stream = stellarstation_swig.pdu_to_stream(gr.sizeof_gr_complex)
+        pdu_filter = blocks.pdu_filter(pmt.intern("FRAMING"), pmt.from_uint64(0))  # Parse only packets with Bitstream Framing
+        pdu_to_stream = stellarstation_swig.pdu_to_stream(gr.sizeof_char)
 
         self.msg_connect((api_source, 'out'), (pdu_filter, 'pdus'))
         self.msg_connect((pdu_filter, 'pdus'), (pdu_to_stream, 'pdu'))

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -22,7 +22,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 import pmt
-from stellarstation import stellarstation_swig
+from gr_stellarstation import stellarstation_swig
 
 
 class iq_source(gr.hier_block2):

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -31,6 +31,14 @@ class iq_source(gr.hier_block2):
     using the Stellarstation API.
     """
     def __init__(self, satellite_id, stream_id, key_path, root_cert_path="", api_url="api.stellarstation.com"):
+        """
+        :param satellite_id: Satellite ID to connect to
+        :param stream_id: Stream ID to connect to. Can be an empty string.
+        :param key_path: Path to JSON API Key
+        :param root_cert_path: Path to root certificate for development server.
+        Leave blank for connecting to the real API
+        :param api_url: API URL to connect to.
+        """
         gr.hier_block2.__init__(self,
             "iq_source",
             gr.io_signature(0, 0, 0),  # Input signature

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -38,7 +38,7 @@ class iq_source(gr.hier_block2):
 
         # Define blocks and connect them
         api_source = stellarstation_swig.api_source(satellite_id, stream_id, key_path, root_cert_path, api_url)
-        pdu_filter = blocks.pdu_filter(pmt.intern("Framing"), pmt.from_uint64(0))  # Parse only packets with IQ Framing
+        pdu_filter = blocks.pdu_filter(pmt.intern("FRAMING"), pmt.from_uint64(0))  # Parse only packets with IQ Framing
         pdu_to_stream = stellarstation_swig.pdu_to_stream(gr.sizeof_gr_complex)
 
         self.msg_connect((api_source, 'out'), (pdu_filter, 'pdus'))

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -36,7 +36,7 @@ class iq_source(gr.hier_block2):
         :param stream_id: Stream ID to connect to. Can be an empty string.
         :param key_path: Path to JSON API Key
         :param root_cert_path: Path to root certificate for development server.
-        Leave blank for connecting to the real API
+        Leave blank when connecting to the real API
         :param api_url: API URL to connect to.
         """
         gr.hier_block2.__init__(self,

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -20,6 +20,8 @@
 # 
 
 from gnuradio import gr
+from gnuradio import blocks
+import pmt
 from stellarstation import stellarstation_swig
 
 
@@ -36,7 +38,9 @@ class iq_source(gr.hier_block2):
 
         # Define blocks and connect them
         api_source = stellarstation_swig.api_source(satellite_id, stream_id, key_path, root_cert_path, api_url)
+        pdu_filter = blocks.pdu_filter(pmt.intern("Framing"), pmt.from_uint64(0))  # Parse only packets with IQ Framing
         pdu_to_stream = stellarstation_swig.pdu_to_stream(gr.sizeof_gr_complex)
 
-        self.msg_connect((api_source, 'out'), (pdu_to_stream, 'pdu'))
+        self.msg_connect((api_source, 'out'), (pdu_filter, 'pdus'))
+        self.msg_connect((pdu_filter, 'pdus'), (pdu_to_stream, 'pdu'))
         self.connect((pdu_to_stream, 0), (self, 0))

--- a/python/iq_source.py
+++ b/python/iq_source.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2018 Infostellar, Inc.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr
+from stellarstation import stellarstation_swig
+
+
+class iq_source(gr.hier_block2):
+    """
+    This hierarchical block contains a block for streaming IQ data from a satellite
+    using the Stellarstation API.
+    """
+    def __init__(self, satellite_id, stream_id, key_path, root_cert_path="", api_url="api.stellarstation.com"):
+        gr.hier_block2.__init__(self,
+            "iq_source",
+            gr.io_signature(0, 0, 0),  # Input signature
+            gr.io_signature(1, 1, gr.sizeof_gr_complex))  # Output signature
+
+        # Define blocks and connect them
+        api_source = stellarstation_swig.api_source(satellite_id, stream_id, key_path, root_cert_path, api_url)
+        pdu_to_stream = stellarstation_swig.pdu_to_stream(gr.sizeof_gr_complex)
+
+        self.msg_connect((api_source, 'out'), (pdu_to_stream, 'pdu'))
+        self.connect((pdu_to_stream, 0), (self, 0))

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -53,7 +53,7 @@ GR_SWIG_MAKE(stellarstation_swig stellarstation_swig.i)
 ########################################################################
 # Install the build swig module
 ########################################################################
-GR_SWIG_INSTALL(TARGETS stellarstation_swig DESTINATION ${GR_PYTHON_DIR}/stellarstation)
+GR_SWIG_INSTALL(TARGETS stellarstation_swig DESTINATION ${GR_PYTHON_DIR}/gr_stellarstation)
 
 ########################################################################
 # Install swig .i files for development

--- a/swig/stellarstation_swig.i
+++ b/swig/stellarstation_swig.i
@@ -9,8 +9,11 @@
 
 %{
 #include "stellarstation/api_source.h"
+#include "stellarstation/pdu_to_stream.h"
 %}
 
 
 %include "stellarstation/api_source.h"
 GR_SWIG_BLOCK_MAGIC2(stellarstation, api_source);
+%include "stellarstation/pdu_to_stream.h"
+GR_SWIG_BLOCK_MAGIC2(stellarstation, pdu_to_stream);

--- a/swig/stellarstation_swig.i
+++ b/swig/stellarstation_swig.i
@@ -8,6 +8,9 @@
 %include "stellarstation_swig_doc.i"
 
 %{
+#include "stellarstation/api_source.h"
 %}
 
 
+%include "stellarstation/api_source.h"
+GR_SWIG_BLOCK_MAGIC2(stellarstation, api_source);


### PR DESCRIPTION
This PR adds Stellarstation source blocks.

The core block communicating with the Stellarstation API is the api_source block. It is responsible for receiving packets from the API and sending them as PMTs (in PDU format https://wiki.gnuradio.org/index.php/Guided_Tutorial_Programming_Topics#5.3.1_PDUs) for downstream blocks to consume. 

Two hierarchical blocks, Stellarstation IQ Source and Stellarstation Bitstream Source are also provided. These blocks contain api_source but specifically look for the IQ/Bitstream packets (respectively) received and outputs them as a stream. I expect these blocks to be the ones mostly used by users.

![screenshot from 2018-08-17 15-54-46](https://user-images.githubusercontent.com/18363734/44252090-fb6d2280-a235-11e8-8703-dd93ca9099eb.png)

For people who actually want to use more than one type of data from the satellite in a flowgraph, they can use the api_source block directly and the built-in GNURadio PDU Filter blocks to process their downstream packets. This could be considered advanced usage.

![screenshot from 2018-08-17 16-00-56](https://user-images.githubusercontent.com/18363734/44252380-e9d84a80-a236-11e8-850a-af2122779a31.png)

Documentation and examples will be done in a separate PR.

Will also move to Conan for installing generated protobuf in a separate PR.